### PR TITLE
Add sniffer callback

### DIFF
--- a/client.go
+++ b/client.go
@@ -111,31 +111,32 @@ type Client struct {
 	conns   []*conn      // all connections
 	cindex  int          // index into conns
 
-	mu                        sync.RWMutex  // guards the next block
-	urls                      []string      // set of URLs passed initially to the client
-	running                   bool          // true if the client's background processes are running
-	errorlog                  Logger        // error log for critical messages
-	infolog                   Logger        // information log for e.g. response times
-	tracelog                  Logger        // trace log for debugging
-	maxRetries                int           // max. number of retries
-	scheme                    string        // http or https
-	healthcheckEnabled        bool          // healthchecks enabled or disabled
-	healthcheckTimeoutStartup time.Duration // time the healthcheck waits for a response from Elasticsearch on startup
-	healthcheckTimeout        time.Duration // time the healthcheck waits for a response from Elasticsearch
-	healthcheckInterval       time.Duration // interval between healthchecks
-	healthcheckStop           chan bool     // notify healthchecker to stop, and notify back
-	snifferEnabled            bool          // sniffer enabled or disabled
-	snifferTimeoutStartup     time.Duration // time the sniffer waits for a response from nodes info API on startup
-	snifferTimeout            time.Duration // time the sniffer waits for a response from nodes info API
-	snifferInterval           time.Duration // interval between sniffing
-	snifferStop               chan bool     // notify sniffer to stop, and notify back
-	decoder                   Decoder       // used to decode data sent from Elasticsearch
-	basicAuth                 bool          // indicates whether to send HTTP Basic Auth credentials
-	basicAuthUsername         string        // username for HTTP Basic Auth
-	basicAuthPassword         string        // password for HTTP Basic Auth
-	sendGetBodyAs             string        // override for when sending a GET with a body
-	requiredPlugins           []string      // list of required plugins
-	gzipEnabled               bool          // gzip compression enabled or disabled (default)
+	mu                        sync.RWMutex    // guards the next block
+	urls                      []string        // set of URLs passed initially to the client
+	running                   bool            // true if the client's background processes are running
+	errorlog                  Logger          // error log for critical messages
+	infolog                   Logger          // information log for e.g. response times
+	tracelog                  Logger          // trace log for debugging
+	maxRetries                int             // max. number of retries
+	scheme                    string          // http or https
+	healthcheckEnabled        bool            // healthchecks enabled or disabled
+	healthcheckTimeoutStartup time.Duration   // time the healthcheck waits for a response from Elasticsearch on startup
+	healthcheckTimeout        time.Duration   // time the healthcheck waits for a response from Elasticsearch
+	healthcheckInterval       time.Duration   // interval between healthchecks
+	healthcheckStop           chan bool       // notify healthchecker to stop, and notify back
+	snifferEnabled            bool            // sniffer enabled or disabled
+	snifferTimeoutStartup     time.Duration   // time the sniffer waits for a response from nodes info API on startup
+	snifferTimeout            time.Duration   // time the sniffer waits for a response from nodes info API
+	snifferInterval           time.Duration   // interval between sniffing
+	snifferCallback           SnifferCallback // callback to modify the sniffing decision
+	snifferStop               chan bool       // notify sniffer to stop, and notify back
+	decoder                   Decoder         // used to decode data sent from Elasticsearch
+	basicAuth                 bool            // indicates whether to send HTTP Basic Auth credentials
+	basicAuthUsername         string          // username for HTTP Basic Auth
+	basicAuthPassword         string          // password for HTTP Basic Auth
+	sendGetBodyAs             string          // override for when sending a GET with a body
+	requiredPlugins           []string        // list of required plugins
+	gzipEnabled               bool            // gzip compression enabled or disabled (default)
 }
 
 // NewClient creates a new client to work with Elasticsearch.
@@ -204,6 +205,7 @@ func NewClient(options ...ClientOptionFunc) (*Client, error) {
 		snifferTimeoutStartup:     DefaultSnifferTimeoutStartup,
 		snifferTimeout:            DefaultSnifferTimeout,
 		snifferInterval:           DefaultSnifferInterval,
+		snifferCallback:           nopSnifferCallback,
 		snifferStop:               make(chan bool),
 		sendGetBodyAs:             DefaultSendGetBodyAs,
 		gzipEnabled:               DefaultGzipEnabled,
@@ -306,6 +308,7 @@ func NewSimpleClient(options ...ClientOptionFunc) (*Client, error) {
 		snifferTimeoutStartup:     off,
 		snifferTimeout:            off,
 		snifferInterval:           off,
+		snifferCallback:           nopSnifferCallback,
 		snifferStop:               make(chan bool),
 		sendGetBodyAs:             DefaultSendGetBodyAs,
 		gzipEnabled:               DefaultGzipEnabled,
@@ -433,6 +436,27 @@ func SetSnifferTimeout(timeout time.Duration) ClientOptionFunc {
 func SetSnifferInterval(interval time.Duration) ClientOptionFunc {
 	return func(c *Client) error {
 		c.snifferInterval = interval
+		return nil
+	}
+}
+
+// SnifferCallback defines the protocol for sniffing decisions.
+type SnifferCallback func(*NodesInfoNode) bool
+
+// nopSnifferCallback is the default sniffer callback: It accepts
+// all nodes the sniffer finds.
+var nopSnifferCallback = func(*NodesInfoNode) bool { return true }
+
+// SetSnifferCallback allows the caller to modify sniffer decisions.
+// When setting the callback, the given SnifferCallback is called for
+// each (healthy) node found during the sniffing process.
+// If the callback returns false, the node is ignored: No requests
+// are routed to it.
+func SetSnifferCallback(f SnifferCallback) ClientOptionFunc {
+	return func(c *Client) error {
+		if f != nil {
+			c.snifferCallback = f
+		}
 		return nil
 	}
 }
@@ -797,10 +821,12 @@ func (c *Client) sniffNode(url string) []*conn {
 	if err := json.NewDecoder(res.Body).Decode(&info); err == nil {
 		if len(info.Nodes) > 0 {
 			for nodeID, node := range info.Nodes {
-				if node.HTTP != nil && len(node.HTTP.PublishAddress) > 0 {
-					url := c.extractHostname(c.scheme, node.HTTP.PublishAddress)
-					if url != "" {
-						nodes = append(nodes, newConn(nodeID, url))
+				if c.snifferCallback(node) {
+					if node.HTTP != nil && len(node.HTTP.PublishAddress) > 0 {
+						url := c.extractHostname(c.scheme, node.HTTP.PublishAddress)
+						if url != "" {
+							nodes = append(nodes, newConn(nodeID, url))
+						}
 					}
 				}
 			}

--- a/client_test.go
+++ b/client_test.go
@@ -159,6 +159,23 @@ func TestClientSniffFailure(t *testing.T) {
 	}
 }
 
+func TestClientSnifferCallback(t *testing.T) {
+	var calls int
+	cb := func(node *NodesInfoNode) bool {
+		calls++
+		return false
+	}
+	_, err := NewClient(
+		SetURL("http://127.0.0.1:19200", "http://127.0.0.1:9200"),
+		SetSnifferCallback(cb))
+	if err == nil {
+		t.Fatalf("expected cluster to fail with no nodes found")
+	}
+	if calls != 1 {
+		t.Fatalf("expected 1 call to the sniffer callback, got %d", calls)
+	}
+}
+
 func TestClientSniffDisabled(t *testing.T) {
 	client, err := NewClient(SetSniff(false), SetURL("http://127.0.0.1:9200", "http://127.0.0.1:9201"))
 	if err != nil {


### PR DESCRIPTION
SnifferCallback allows callers to intercept in the sniffing process and decide which (healthy) nodes are considered for receiving requests.

When the sniffing process finds a healthy node, the callback is invoked with the [`NodesInfoNode`](https://github.com/olivere/elastic/blob/release-branch.v5/nodes_info.go#L136) struct passed into it. The callback can inspect that struct and return false when the node should be ignored. No requests are routed to that node by the client.

Example:

```go
func MySnifferCallback(node *elastic.NodeInfoNode) bool {
        // This sniffer simply ignores node with name "node1"
        if node.Name == "node1" {
                return false
        }
        return true
}

...

client, err := elastic.NewClient(
        elastic.SetSnifferCallback(MySnifferCallback))
if err != nil {
        log.Fatal(err)
}
```

The official clients have a similar feature, e.g. the [`nodesToHostCallback` in the Node.js
client](https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current/configuration.html).

See #388 for further discussion.